### PR TITLE
Update Csvwriter.php to fix deprecation warning

### DIFF
--- a/src/Utils/Csvwriter.php
+++ b/src/Utils/Csvwriter.php
@@ -45,12 +45,10 @@ class Csvwriter {
      * @param string $name the name of the file. Default: "file_" . rand()
      * @param array The flattened data
      */
-    public function writeCsv($name = '', $dataFlattened) {
-        $fileName = !empty($name) ? $name : "file_" . rand();
+    public function writeCsv($name, $dataFlattened) {
         // Setting data        
-
         $csvFormat = $this->arrayToCsv($dataFlattened);
-        $this->writeCsvToFile($csvFormat, $fileName);
+        $this->writeCsvToFile($csvFormat, $name);
     }
 
     private function arrayToCsv($data) {


### PR DESCRIPTION
The name is already made optional from the only calling function NestedJsonFlattener\Flattener\Flattener::writeCsv()